### PR TITLE
Include <libgen.h>.

### DIFF
--- a/source/linux/main.cpp
+++ b/source/linux/main.cpp
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <errno.h>
 #include <vector>
+#include <libgen.h>
 
 #include "core/api/NstApiEmulator.hpp"
 #include "core/api/NstApiVideo.hpp"


### PR DESCRIPTION
Include &lt;libgen.h>. Otherwise OpenBSD build errors out on basename().
