### PR TITLE
Fix scrolling in The Young Indiana Jones Chronicels

### DIFF
--- a/source/core/NstPpu.hpp
+++ b/source/core/NstPpu.hpp
@@ -176,6 +176,7 @@ namespace Nes
 
 			NST_FORCE_INLINE void UpdateAddressLine(uint);
 			NST_FORCE_INLINE void UpdateScrollAddressLine();
+      NST_FORCE_INLINE void UpdateVramAddress();
 
 			NST_FORCE_INLINE void OpenName();
 			NST_FORCE_INLINE void FetchName();


### PR DESCRIPTION
This fix emulates some undocumented PPU behavior when a read or write is done at address $2007 when not in vblank.  This fixes the garbage on screen when scrolling vertically in The Young Indiana Jones Chronicles.

Credit for this goes to NESDev board members James, who originally figured out the undocumented behavior, and plasturion, who initially implemented this in Nestopia.
