### PR TITLE
Oversize mapper 180

### DIFF
--- a/source/core/board/NstBoard.cpp
+++ b/source/core/board/NstBoard.cpp
@@ -2734,8 +2734,15 @@ namespace Nes
 
 					case 180:
 
-						name = "NIHON UNROM M5";
-						id = Type::NIHON_UNROM_M5;
+						if (!chr && !wram && (nmt == Type::NMT_HORIZONTAL || nmt == Type::NMT_VERTICAL) && prg == SIZE_128K)
+						{
+							name = "NIHON UNROM M5";
+							id = Type::NIHON_UNROM_M5;
+							break;
+						}
+
+						name = "UxROM-AND (non-standard)";
+						id = Type::UNL_UXROM_M5;
 						break;
 
 					case 182:
@@ -3461,6 +3468,7 @@ namespace Nes
 					case Type::NAMCOT_163_S_0             :
 					case Type::NAMCOT_163_S_1             : return new Namcot::N163(c);
 					case Type::NANJING_STD                : return new Nanjing::Standard(c);
+					case Type::UNL_UXROM_M5               :
 					case Type::NIHON_UNROM_M5             : return new Nihon::UnRomM5(c);
 					case Type::NITRA_TDA                  : return new Nitra::Tda(c);
 					case Type::NTDEC_N715062              : return new Ntdec::N715062(c);

--- a/source/core/board/NstBoard.hpp
+++ b/source/core/board/NstBoard.hpp
@@ -540,6 +540,7 @@ namespace Nes
 						UNL_GXROM                  = MakeId<   66,  512,  128,  8,  0, CRM_0,  NMT_X,  0 >::ID,
 						UNL_NROM                   = MakeId<    0,   32,    8,  8,  0, CRM_8,  NMT_X,  0 >::ID,
 						UNL_UXROM                  = MakeId<    2, 4096,    8,  8,  0, CRM_0,  NMT_X,  0 >::ID,
+						UNL_UXROM_M5               = MakeId<  180, 4096,    8,  8,  0, CRM_0,  NMT_X,  0 >::ID,
 						UNL_TRXROM                 = MakeId<    4,  512,  256,  8,  0, CRM_0,  NMT_4,  0 >::ID,
 						UNL_XZY                    = MakeId<  176, 1024,  256,  8,  0, CRM_0,  NMT_X,  0 >::ID,
 						// Waixing


### PR DESCRIPTION
Mapper 180 is discrete logic, so the hardware is trivially extensible beyond the only game that came that way. It'd be nice if Nestopia supported larger ones.

I'm not strictly sold on calling it "UxROM-AND" if you'd rather have something else.
