### PR TITLE
Remove a wrong terminating semicolon for a for loop.

### DIFF
--- a/source/core/NstCartridgeInes.cpp
+++ b/source/core/NstCartridgeInes.cpp
@@ -849,7 +849,7 @@ namespace Nes
 
 				header[11] |= i;
 
-				for (i=0, data=setup.chrNvRam >> 7; data; data >>= 1, ++i);
+				for (i=0, data=setup.chrNvRam >> 7; data; data >>= 1, ++i)
 				{
 					if (i > 0xF)
 						return RESULT_ERR_INVALID_PARAM;


### PR DESCRIPTION
With this semicolon present, the inside of the for loop would never be executed.
