### PR TITLE
Fix a typo within a conditional in NstCartridgeUnif.

### DIFF
--- a/source/core/NstCartridgeUnif.cpp
+++ b/source/core/NstCartridgeUnif.cpp
@@ -346,7 +346,7 @@ namespace Nes
 				{
 					profile.board.solderPads = Profile::Board::SOLDERPAD_V;
 				}
-				else if (profileEx.nmt == ProfileEx::NMT_HORIZONTAL)
+				else if (profileEx.nmt == ProfileEx::NMT_VERTICAL)
 				{
 					profile.board.solderPads = Profile::Board::SOLDERPAD_H;
 				}


### PR DESCRIPTION
Previously, it would apply SOLDERPAD_V even when nmt was NMT_HORIZONTAL.
