### PR TITLE
Core: Fix the use of uninitialized class members being used within the initialization lists.

### DIFF
--- a/source/core/NstMachine.hpp
+++ b/source/core/NstMachine.hpp
@@ -122,14 +122,13 @@ namespace Nes
 			dword frame;
 
 		public:
-
+			Cpu cpu;
 			Input::Adapter* extPort;
 			Input::Device* expPort;
 			Image* image;
 			Cheats* cheats;
 			ImageDatabase* imageDatabase;
 			Tracker tracker;
-			Cpu cpu;
 			Ppu ppu;
 			Video::Renderer renderer;
 

--- a/source/core/NstPpu.hpp
+++ b/source/core/NstPpu.hpp
@@ -345,6 +345,9 @@ namespace Nes
 
 				typedef void (Ppu::*Phase)();
 
+				byte ram[0x100];
+				byte buffer[MAX_LINE_SPRITES * 4];
+
 				const byte* limit;
 				Output* visible;
 				Phase phase;
@@ -357,9 +360,6 @@ namespace Nes
 				byte show[2];
 				bool spriteZeroInLine;
 				bool spriteLimit;
-
-				byte ram[0x100];
-				byte buffer[MAX_LINE_SPRITES*4];
 
 				Output output[MAX_LINE_SPRITES];
 			};
@@ -414,9 +414,7 @@ namespace Nes
 			Chr chr;
 			Nmt nmt;
 			int scanline;
-		public:
-			Output output;
-		private:
+
 			PpuModel model;
 			Hook hActiveHook;
 			Hook hBlankHook;
@@ -431,6 +429,7 @@ namespace Nes
 			static const byte yuvMaps[4][0x40];
 
 		public:
+			Output output;
 
 			void Update()
 			{


### PR DESCRIPTION
I noticed that in some cases currently uninitialized variables are used to initialize some things in the initializer lists. The reason for this is the standard dictates that class members are initialized in the order they are declared within the class (specifically this is section 12.6.2, point 10; in case you'd like to see it yourself)

Here's a list of where this happens for documentation sake.
- [NstMachine.cpp](https://github.com/rdanbrook/nestopia/blob/master/source/core/NstMachine.cpp#L48)
  cpu is used in extPort and expPort's initializations.
- [NstPpu.cpp (line 86)](https://github.com/rdanbrook/nestopia/blob/master/source/core/NstPpu.cpp#L86)
  buffer would not actually be initialized in this case.
- [NstPpu.cpp (line 105)](https://github.com/rdanbrook/nestopia/blob/master/source/core/NstPpu.cpp#L105)
  screen would not be initialized at this point due to it being further down in the class member declarations.
