### PR TITLE
Ubuntu build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ configure
 depcomp
 install-sh
 missing
+source/common/.deps/
+source/common/.dirstamp
 source/core/.deps/
 source/core/.dirstamp
 source/core/api/.deps/
@@ -34,8 +36,10 @@ source/core/input/.deps/
 source/core/input/.dirstamp
 source/core/vssystem/.deps/
 source/core/vssystem/.dirstamp
+source/gtkui/.deps/
+source/sdl/.deps/
+source/sdl/.dirstamp
 source/unix/.deps/
 source/unix/.dirstamp
 source/unix/gtkui/.deps/
 source/unix/gtkui/.dirstamp
-

--- a/source/common/cheats.cpp
+++ b/source/common/cheats.cpp
@@ -20,6 +20,7 @@
  * 
  */
 
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
I just built Nestopia on Ubuntu 16.04. In the process, I had to `sudo apt-get install autoconf-archive libarchive-dev libsdl2-dev libepoxy-dev`. I believe this is at least partially responsible for the new directories I need to add to `.gitignore` to keep my tree clean.

Further, I had to add `#include <cstdlib>` to `cheats.cpp` because the use of `wcstombs` was unrecognized without it (http://www.cplusplus.com/reference/cstdlib/wcstombs/).