### PR TITLE
Use XDG base directories to store configs and data

### DIFF
--- a/source/common/config.cpp
+++ b/source/common/config.cpp
@@ -30,22 +30,22 @@
 
 settings_t conf;
 
-void config_file_read(const char *nstdir) {
+void config_file_read(const char *confdir) {
 	// Read the config file
 
 	char confpath[256];
-	snprintf(confpath, sizeof(confpath), "%snestopia.conf", nstdir);
+	snprintf(confpath, sizeof(confpath), "%snestopia.conf", confdir);
 
 	if (ini_parse(confpath, config_match, &conf) < 0) {
 		fprintf(stderr, "Failed to read config file %s: Using defaults.\n", confpath);
 	}
 }
 
-void config_file_write(const char *nstdir) {
+void config_file_write(const char *confdir) {
 	// Write the config file
 	
 	char confpath[256];
-	snprintf(confpath, sizeof(confpath), "%snestopia.conf", nstdir);
+	snprintf(confpath, sizeof(confpath), "%snestopia.conf", confdir);
 	
 	FILE *fp = fopen(confpath, "w");
 	if (fp != NULL)	{

--- a/source/common/config.h
+++ b/source/common/config.h
@@ -68,8 +68,8 @@ typedef struct {
 	int misc_homebrew_stderr;
 } settings_t;
 
-void config_file_read(const char *nstdir);
-void config_file_write(const char *nstdir);
+void config_file_read(const char *confdir);
+void config_file_write(const char *confdir);
 void config_set_default();
 static int config_match(void* user, const char* section, const char* name, const char* value);
 

--- a/source/common/nstcommon.cpp
+++ b/source/common/nstcommon.cpp
@@ -645,13 +645,35 @@ void nst_set_dirs() {
 	snprintf(nstpaths.nstdir, sizeof(nstpaths.nstdir), "");
 #else
 	// create system directory if it doesn't exist
-	snprintf(nstpaths.nstdir, sizeof(nstpaths.nstdir), "%s/.nestopia/", getenv("HOME"));
+	const char* datadir = getenv("XDG_DATA_HOME");
+	char dirstr[256];
+	if (!datadir) {
+		snprintf(dirstr, sizeof(dirstr), "%s/.local/share", getenv("HOME"));
+		datadir = dirstr;
+	}
+	snprintf(nstpaths.nstdir, sizeof(nstpaths.nstdir), "%s/nestopia/", datadir);
 	if (mkdir(nstpaths.nstdir, 0755) && errno != EEXIST) {	
 		fprintf(stderr, "Failed to create %s: %d\n", nstpaths.nstdir, errno);
 	}
 #endif
+
+    // Set up config directory
+#ifdef _MINGW
+	snprintf(nstpaths.confdir, sizeof(nstpaths.confdir), "");
+#else
+	// create config directory if it doesn't exist
+	const char* confdir = getenv("XDG_CONFIG_HOME");
+	if (!confdir) {
+		snprintf(dirstr, sizeof(dirstr), "%s/.config", getenv("HOME"));
+		confdir = dirstr;
+	}
+	snprintf(nstpaths.confdir, sizeof(nstpaths.confdir), "%s/nestopia/", confdir);
+	if (mkdir(nstpaths.confdir, 0755) && errno != EEXIST) {
+		fprintf(stderr, "Failed to create %s: %d\n", nstpaths.confdir, errno);
+	}
+#endif
+
 	// create save and state directories if they don't exist
-	char dirstr[256];
 	snprintf(dirstr, sizeof(dirstr), "%ssave", nstpaths.nstdir);
 #ifdef _MINGW	
 	if (mkdir(dirstr) && errno != EEXIST) {

--- a/source/common/nstcommon.h
+++ b/source/common/nstcommon.h
@@ -17,6 +17,7 @@ using namespace Nes::Api;
 
 typedef struct {
 	char nstdir[256];
+    char confdir[256];
 	char savedir[256];
 	char gamename[256];
 	char savename[512];

--- a/source/gtkui/gtkui.cpp
+++ b/source/gtkui/gtkui.cpp
@@ -622,7 +622,7 @@ int main(int argc, char *argv[]) {
 	config_set_default();
 	
 	// Read the config file and override defaults
-	config_file_read(nstpaths.nstdir);
+	config_file_read(nstpaths.confdir);
 	
 	// Handle command line arguments
 	cli_handle_command(argc, argv);
@@ -693,7 +693,7 @@ int main(int argc, char *argv[]) {
 	gtkui_input_config_write();
 	
 	// Write the config file
-	config_file_write(nstpaths.nstdir);
+	config_file_write(nstpaths.confdir);
 
 	return 0;
 }

--- a/source/gtkui/gtkui_input.cpp
+++ b/source/gtkui/gtkui_input.cpp
@@ -140,7 +140,7 @@ void gtkui_input_set_default() {
 
 void gtkui_input_config_read() {
 	// Read the input config file
-	snprintf(inputconfpath, sizeof(inputconfpath), "%sgtkinput.conf", nstpaths.nstdir);
+	snprintf(inputconfpath, sizeof(inputconfpath), "%sgtkinput.conf", nstpaths.confdir);
 	if (ini_parse(inputconfpath, gtkui_input_config_match, &inputconf) < 0) {
 		fprintf(stderr, "Failed to load input config file %s: Using defaults.\n", inputconfpath);
 	}

--- a/source/sdl/sdlinput.cpp
+++ b/source/sdl/sdlinput.cpp
@@ -560,7 +560,7 @@ static int nstsdl_input_config_match(void* user, const char* section, const char
 
 void nstsdl_input_conf_read() {
 	// Read the input config file
-	snprintf(inputconfpath, sizeof(inputconfpath), "%sinput.conf", nstpaths.nstdir);
+	snprintf(inputconfpath, sizeof(inputconfpath), "%sinput.conf", nstpaths.confdir);
 	
 	if (ini_parse(inputconfpath, nstsdl_input_config_match, &inputconf) < 0) {
 		fprintf(stderr, "Failed to load input config file %s: Using defaults.\n", inputconfpath);

--- a/source/sdl/sdlmain.cpp
+++ b/source/sdl/sdlmain.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
 	config_set_default();
 	
 	// Read the config file and override defaults
-	config_file_read(nstpaths.nstdir);
+	config_file_read(nstpaths.confdir);
 	
 	// Exit if there is no CLI argument
 	if (argc == 1) {
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
 	nstsdl_input_conf_write();
 	
 	// Write the config file
-	config_file_write(nstpaths.nstdir);
+	config_file_write(nstpaths.confdir);
 
 	return 0;
 }


### PR DESCRIPTION
nstdir now points to $XDG_DATA_HOME/nestopia/ and config files are stored
in $XDG_CONFIG_HOME/nestopia/ to conform to XDG base directory
specification.

This is a preliminary pull request, I've simply changed the respective hardcoded paths.
It does not consider compatibility with previous configuration, or trying it move it over etc.

Motivation:
A majority of desktop applications and environments have now switched to using XDG paths,
and this leads to a more organized file structure and uncluttered home directory, among other things.
Spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

