### PR TITLE
Notcurses support for console graphics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,11 @@ nestopia_LDADD = \
 	$(SDL2_LIBS) \
 	$(LIBEPOXY_LIBS)
 
+if ENABLE_TUI
+nestopia_CPPFLAGS += $(NOTCURSES_CFLAGS)
+nestopia_LDADD += $(NOTCURSES_LIBS)
+endif
+
 if ENABLE_GUI
 nestopia_CPPFLAGS += -D_GTK $(GTK3_CFLAGS)
 nestopia_LDADD += $(GTK3_LIBS)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The following platforms are supported:
 This project depends on the following libraries:
 libsdl2, libepoxy, libao, libarchive, zlib
 
-Optionally, it depends on GTK+3 for the GUI, currently only available on Linux and BSD.
+Optionally, it depends on GTK+3 for the GUI, or notcurses for character-based
+graphics. Both are available only on Linux and BSD.
 
 ## Installing Dependencies
 Install dependencies required for building on Debian-based Linux distributions:
@@ -24,14 +25,14 @@ apt-get install build-essential autoconf autoconf-archive automake autotools-dev
 ```
 Optional dependencies:
 ```
-apt-get install libao-dev libjack-dev libgtk-3-dev
+apt-get install libao-dev libjack-dev libgtk-3-dev libnotcurses-dev
 ```
 
 ## Building
 To build using Autotools (optional arguments in square brackets):
 ```
 autoreconf -vif
-./configure [--enable-gui] [--enable-doc] [--with-ao] [--with-jack]
+./configure [--enable-tui] [--enable-gui] [--enable-doc] [--with-ao] [--with-jack]
 make
 ```
 Optionally:

--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,7 @@ AS_IF([test "x$enable_tui" = "xyes"], [
 	if test "x$enable_gui" = "xyes"; then
 		AC_MSG_ERROR([--enable-tui cannot be used with --enable-gui])
 	fi
-	PKG_CHECK_MODULES([NOTCURSES], [notcurses >= 1.1.6])
+	PKG_CHECK_MODULES([NOTCURSES], [notcurses >= 2.0.5])
 	NOTCURSES_CFLAGS+=" -D_WITH_NOTCURSES"
 ])
 AM_CONDITIONAL([ENABLE_TUI], [test "x$enable_tui" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,18 @@ AS_IF([test "x$enable_gui" = "xyes"], [
 ])
 AM_CONDITIONAL([ENABLE_GUI], [test "x$enable_gui" = "xyes"])
 
+AC_ARG_ENABLE([tui],
+	AS_HELP_STRING([--enable-tui], [Enable building TUI with notcurses]))
+
+AS_IF([test "x$enable_tui" = "xyes"], [
+	if test "x$enable_gui" = "xyes"; then
+		AC_MSG_ERROR([--enable-tui cannot be used with --enable-gui])
+	fi
+	PKG_CHECK_MODULES([NOTCURSES], [notcurses >= 1.1.6])
+	NOTCURSES_CFLAGS+=" -D_WITH_NOTCURSES"
+])
+AM_CONDITIONAL([ENABLE_TUI], [test "x$enable_tui" = "xyes"])
+
 dnl full HTML suite
 AC_ARG_ENABLE([doc],
 	AS_HELP_STRING([--enable-doc], [Install full HTML documentation]))

--- a/source/common/cli.cpp
+++ b/source/common/cli.cpp
@@ -39,7 +39,10 @@ void cli_show_usage() {
 	//printf("  -d, --disablegui        Disable GTK+ GUI\n");
 	//printf("  -e, --enablegui         Enable GTK+ GUI\n\n");
 	printf("  -f, --fullscreen        Fullscreen mode\n");
-	printf("  -w, --window            Window mode\n\n");
+	printf("  -w, --window            Window mode\n");
+#ifdef _WITH_NOTCURSES
+	printf("  -x, --text              Text mode\n\n");
+#endif
 	printf("  -l, --filter            Video Filter\n");
 	printf("                          (0=None, 1=NTSC, 2=xBR, 3=HqX, 4=2xSaI, 5=ScaleX)\n\n");
 	printf("  -m, --maskoverscan      Mask overscan areas\n");
@@ -70,6 +73,9 @@ void cli_handle_command(int argc, char *argv[]) {
 			{"enablegui", no_argument, 0, 'e'},
 			{"fullscreen", no_argument, 0, 'f'},
 			{"window", no_argument, 0, 'w'},
+#ifdef _WITH_NOTCURSES
+			{"text", no_argument, 0, 'x'},
+#endif
 			{"help", no_argument, 0, 'h'},
 			{"filter", required_argument, 0, 'l'},
 			{"maskoverscan", no_argument, 0, 'm'},
@@ -87,8 +93,11 @@ void cli_handle_command(int argc, char *argv[]) {
 		
 		int option_index = 0;
 		
-		c = getopt_long(argc, argv, "defhl:mnopqrs:tuvw",
-			long_options, &option_index);
+		c = getopt_long(argc, argv, "defhl:mnopqrs:tuvw"
+#ifdef _WITH_NOTCURSES
+	"x"
+#endif
+			, long_options, &option_index);
 		
 		if (c == -1) { break; }
 		
@@ -96,16 +105,23 @@ void cli_handle_command(int argc, char *argv[]) {
 			/*case 'd':
 				conf.misc_disable_gui = true;
 				break;
-			
+
 			case 'e':
 				conf.misc_disable_gui = false;
 				break;*/
-			
+
 			case 'f':
 				conf.video_fullscreen = true;
+				conf.video_text = false;
 				break;
-			
+
 			case 'w':
+				conf.video_fullscreen = false;
+				conf.video_text = false;
+				break;
+
+			case 'x':
+				conf.video_text = true;
 				conf.video_fullscreen = false;
 				break;
 			

--- a/source/common/config.h
+++ b/source/common/config.h
@@ -23,6 +23,7 @@ typedef struct {
 	bool video_tv_aspect;
 	bool video_unmask_overscan;
 	bool video_fullscreen;
+	bool video_text;
 	bool video_stretch_aspect;
 	bool video_unlimited_sprites;
 	bool video_xbr_pixel_blending;

--- a/source/common/video.cpp
+++ b/source/common/video.cpp
@@ -163,8 +163,23 @@ void nst_ogl_deinit() {
 	if (vbo) { glDeleteBuffers(1, &vbo); }
 }
 
+#ifdef _WITH_NOTCURSES
+int nst_notcurses_render(struct notcurses *nc) {
+	if (ncblit_bgrx(notcurses_stdplane(nc), 0, 0, 4 * basesize.w,
+		      (const unsigned char*)(videobuf + 8192), 0, 0,
+		      overscan_height, basesize.w)) {
+		return -1;
+	}
+	if (notcurses_render(nc)) {
+		return -1;
+	}
+	return 0;
+}
+#endif
+
 void nst_ogl_render() {
 	// Render the scene
+
 	glTexImage2D(GL_TEXTURE_2D,
 				0,
 				GL_RGBA,
@@ -174,7 +189,6 @@ void nst_ogl_render() {
 				GL_BGRA,
 				GL_UNSIGNED_BYTE,
 		videobuf + overscan_offset);
-	
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -190,7 +204,7 @@ void nst_video_refresh() {
 
 void video_init() {
 	// Initialize video
-	
+
 	nst_ogl_deinit();
 	
 	video_set_dimensions();

--- a/source/common/video.cpp
+++ b/source/common/video.cpp
@@ -165,9 +165,13 @@ void nst_ogl_deinit() {
 
 #ifdef _WITH_NOTCURSES
 int nst_notcurses_render(struct notcurses *nc) {
-	if (ncblit_bgrx(notcurses_stdplane(nc), 0, 0, 4 * basesize.w,
-		      (const unsigned char*)(videobuf + 8192), 0, 0,
-		      overscan_height, basesize.w) < 0) {
+	struct ncvisual_options vopts = {
+		.n = notcurses_stdplane(nc),
+		.leny = overscan_height,
+		.lenx = basesize.w,
+		.blitter = NCBLIT_2x1,
+	};
+	if (ncblit_bgrx(videobuf + overscan_offset, 4 * basesize.w, &vopts) < 0) {
 		return -1;
 	}
 	if (notcurses_render(nc)) {

--- a/source/common/video.cpp
+++ b/source/common/video.cpp
@@ -167,7 +167,7 @@ void nst_ogl_deinit() {
 int nst_notcurses_render(struct notcurses *nc) {
 	if (ncblit_bgrx(notcurses_stdplane(nc), 0, 0, 4 * basesize.w,
 		      (const unsigned char*)(videobuf + 8192), 0, 0,
-		      overscan_height, basesize.w)) {
+		      overscan_height, basesize.w) < 0) {
 		return -1;
 	}
 	if (notcurses_render(nc)) {

--- a/source/common/video.h
+++ b/source/common/video.h
@@ -15,6 +15,8 @@
 #include <OpenGL/gl.h>
 #endif
 
+struct notcurses;
+
 typedef struct {
 	int w;
 	int h;
@@ -33,6 +35,10 @@ typedef struct {
 void nst_ogl_init();
 void nst_ogl_deinit();
 void nst_ogl_render();
+#ifdef _WITH_NOTCURSES
+#include <notcurses.h>
+int nst_notcurses_render(struct notcurses *nc);
+#endif
 
 void video_init();
 void video_toggle_fullscreen();

--- a/source/common/video.h
+++ b/source/common/video.h
@@ -36,7 +36,7 @@ void nst_ogl_init();
 void nst_ogl_deinit();
 void nst_ogl_render();
 #ifdef _WITH_NOTCURSES
-#include <notcurses.h>
+#include <notcurses/notcurses.h>
 int nst_notcurses_render(struct notcurses *nc);
 #endif
 

--- a/source/sdl/sdlmain.cpp
+++ b/source/sdl/sdlmain.cpp
@@ -111,6 +111,7 @@ int main(int argc, char *argv[]) {
 #ifdef _WITH_NOTCURSES
 			if (conf.video_text) {
 				notcurses_options opts{};
+        opts.inhibit_alternate_screen = true;
 				nc = notcurses_init(&opts, stdout);
 				if (!nc) {
 					exit(EXIT_FAILURE);

--- a/source/sdl/sdlmain.cpp
+++ b/source/sdl/sdlmain.cpp
@@ -110,8 +110,8 @@ int main(int argc, char *argv[]) {
 		else {
 #ifdef _WITH_NOTCURSES
 			if (conf.video_text) {
-				notcurses_options opts{};
-        opts.inhibit_alternate_screen = true;
+				notcurses_options opts = {0};
+        opts.flags = NCOPTION_NO_ALTERNATE_SCREEN;
 				nc = notcurses_init(&opts, stdout);
 				if (!nc) {
 					exit(EXIT_FAILURE);


### PR DESCRIPTION
notcurses provides DirectColor RGB and other advanced
capabilities in character graphics mode. This adds
autotools support for an --enable-tui option (exclusive
viz --enable-gui). When compiled with TUI support,
-x/--text can be supplied on the CLI to use notcurses,
rendering directly to the spawning terminal.

A terminal geometry of at least 256x112 is necessary
for perfect fidelity, as is 24-bit color support.

![2020-02-02-024256_1186x922_scrot](https://user-images.githubusercontent.com/143473/73604943-e1c4b580-4565-11ea-8bfc-cf37038dcee9.png)
