### PR TITLE
Makefile.am: remove AUTHORS from dist_doc_DATA

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ iconsvgdir = $(datarootdir)/icons/hicolor/scalable/apps
 dist_iconsvg_DATA = icons/svg/nestopia.svg icons/svg/nespad.svg
 
 # documentation
-dist_doc_DATA = AUTHORS ChangeLog README.md
+dist_doc_DATA = ChangeLog README.md
 dist_html_DATA = readme.html
 
 #####################


### PR DESCRIPTION
Without this change, nestopia doesn't build from a fresh checkout.