### PR TITLE
A fix for halting on old slow single-core machines w/ FLTK UI

### DIFF
--- a/source/fltkui/fltkui.cpp
+++ b/source/fltkui/fltkui.cpp
@@ -509,16 +509,13 @@ int main(int argc, char *argv[]) {
 	while (true) {
 		glarea->redraw();
 
-		if (nstwin->visible() && !Fl::check()) {
+		Fl::check();
+		if (!nstwin->shown()) {
 			break;
 		}
 		else if (!nstwin->shown() && (confwin->shown() || chtwin->shown())) {
 			break;
 		}
-		else if (!Fl::wait()) {
-			break;
-		}
-
 		SDL_Event event;
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {
@@ -531,7 +528,6 @@ int main(int argc, char *argv[]) {
 				default: break;
 			}
 		}
-
 		nst_emuloop();
 		glarea->redraw();
 	}


### PR DESCRIPTION
Fixed that strange hang (likely due to a full buffer or something) on fltkui on slow old single core machines (tested on Pentium M @1.73GHz, PowerPC G4 @1.33GHz).

I also have tweaked it since last night; it should now stop when the window is closed properly again.

Thought I'd make a PR just so it was out there. Did I miss anything important that the old `if` tests were covering by rewriting it like this?