### PR TITLE
FLTK: use nst prefix for data directories

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,8 @@ EXTRA_DIST = doc
 nestopia_CPPFLAGS = \
 	-I$(top_srcdir)/source \
 	-I$(top_srcdir)/source/fltkui \
-	-DDATADIR=\"$(datadir)/nestopia\" \
-	-DDATAROOTDIR=\"$(datarootdir)\" \
+	-DNST_DATADIR=\"$(datadir)/nestopia\" \
+	-DNST_DATAROOTDIR=\"$(datarootdir)\" \
 	-DNST_PRAGMA_ONCE \
 	$(ZLIB_CFLAGS) \
 	$(LIBARCHIVE_CFLAGS) \

--- a/source/fltkui/fltkui.cpp
+++ b/source/fltkui/fltkui.cpp
@@ -336,7 +336,7 @@ static void fltkui_about(Fl_Widget* w, void* userdata) {
 
 	// Set up the icon
 	char iconpath[512];
-	snprintf(iconpath, sizeof(iconpath), "%s/icons/hicolor/128x128/apps/nestopia.png", DATAROOTDIR);
+	snprintf(iconpath, sizeof(iconpath), "%s/icons/hicolor/128x128/apps/nestopia.png", NST_DATAROOTDIR);
 	// Load the SVG from local source dir if make install hasn't been done
 	struct stat svgstat;
 	if (stat(iconpath, &svgstat) == -1) {

--- a/source/fltkui/nstcommon.cpp
+++ b/source/fltkui/nstcommon.cpp
@@ -336,7 +336,7 @@ void nst_db_load() {
 	}
 
 	// If it fails, try looking in the data directory
-	snprintf(dbpath, sizeof(dbpath), "%s/NstDatabase.xml", DATADIR);
+	snprintf(dbpath, sizeof(dbpath), "%s/NstDatabase.xml", NST_DATADIR);
 	nstdb = new std::ifstream(dbpath, std::ifstream::in|std::ifstream::binary);
 
 	if (nstdb->is_open()) {


### PR DESCRIPTION
Hi,

I'm using nestopia in my "pnes" multi-platform port. On Windows (mingw64), if using curl (which i do), "DATADIR" is already defined in the imported ["objidl.h" header](https://github.com/mirror/mingw-w64/blob/e5151281483edfbd8921bfda3d572b7c339c145c/mingw-w64-headers/include/objidl.h#L10669), which make compilation fail.
I propose to prefix them with the "NST" prefix which is also used for other cflags arguments.