### PR TITLE
fix order of operations

### DIFF
--- a/source/fltkui/video.cpp
+++ b/source/fltkui/video.cpp
@@ -505,7 +505,7 @@ void nst_video_print(const char *text, int xpos, int ypos, int seconds, bool bg)
 	snprintf(osdtext.textbuf, sizeof(osdtext.textbuf), "%s", text);
 	osdtext.xpos = xpos;
 	osdtext.ypos = ypos;
-	osdtext.drawtext = seconds * nst_pal() ? 50 : 60;
+	osdtext.drawtext = seconds * (nst_pal() ? 50 : 60);
 	osdtext.bg = bg;
 }
 


### PR DESCRIPTION
When I build nestopia, the compiler shows the following warning:
```
source/fltkui/video.cpp:508:41: warning: operator '?:' has lower precedence than '*'; '*' will be evaluated first [-Wparentheses]
        osdtext.drawtext = seconds * nst_pal() ? 50 : 60;
                           ~~~~~~~~~~~~~~~~~~~ ^
source/fltkui/video.cpp:508:41: note: place parentheses around the '*' expression to silence this warning
        osdtext.drawtext = seconds * nst_pal() ? 50 : 60;
                                               ^
                           (                  )
source/fltkui/video.cpp:508:41: note: place parentheses around the '?:' expression to evaluate it first
        osdtext.drawtext = seconds * nst_pal() ? 50 : 60;
                                               ^
                                     (                  )
```

From the warning, the default interpretation is `(seconds * nst_pal()) ? 50 : 60`.  This limits possible values to 50 and 60.  (`nst_pal()` returns bool, which is cast as 0 or 1.  The result of `seconds * nst_pal()` is cast back to bool, which is used to decide between 50 and 60).

That is probably not what's wanted.  Based on the variable names, the statement appears to be calculating the frames in some `seconds`.  To obtain the correct result, parentheses are needed: `seconds * (nst_pal() ? 50 : 60)`.