### PR TITLE
Add support for plain compressed files and zstd

### DIFF
--- a/source/fltkui/fltkui.cpp
+++ b/source/fltkui/fltkui.cpp
@@ -101,7 +101,7 @@ static void fltkui_rom_open(Fl_Widget* w, void* userdata) {
 	Fl_Native_File_Chooser fc;
 	fc.title("Select a ROM");
 	fc.type(Fl_Native_File_Chooser::BROWSE_FILE);
-	fc.filter("NES Games\t*.{nes,unf,fds,zip,7z,gz,bz2,xz}");
+	fc.filter("NES Games\t*.{nes,unf,fds,zip,7z,gz,bz2,xz,zst}");
 
 	// Show file chooser
 	switch (fc.show()) {

--- a/source/fltkui/fltkui_archive.cpp
+++ b/source/fltkui/fltkui_archive.cpp
@@ -62,9 +62,7 @@ static void fltkui_archive_setfile(Fl_Widget *w, long) {
 
 bool fltkui_archive_select(const char *filename, char *reqfile, size_t reqsize) {
 	// File not compressed
-	if (nst_archive_checkext(filename)) {
-		return false;
-	}
+	if (nst_archive_checkext(filename)) { return false; }
 
 	// Select a filename to pull out of the archive
 	struct archive *a;
@@ -82,50 +80,51 @@ bool fltkui_archive_select(const char *filename, char *reqfile, size_t reqsize) 
 		r = archive_read_free(a);
 		return false;
 	}
+
 	// If it is an archive, handle it
-	else {
-		if (window) { delete window; }
+	if (window) { delete window; }
 
-		window = new Fl_Double_Window(420, 260, "Load from Archive");
-		browser = new Fl_Select_Browser(0, 0, window->w(), 200, 0);
-		browser->type(FL_HOLD_BROWSER);
-		browser->callback(fltkui_archive_setfile, 0);
-		Fl_Button btncancel(260, 220, 80, 24, "&Cancel");
-		btncancel.callback(fltkui_archive_cancel, 0);
-		Fl_Button btnok(350, 220, 40, 24, "&OK");
-		btnok.callback(fltkui_archive_ok, 0);
+	window = new Fl_Double_Window(420, 260, "Load from Archive");
+	browser = new Fl_Select_Browser(0, 0, window->w(), 200, 0);
+	browser->type(FL_HOLD_BROWSER);
+	browser->callback(fltkui_archive_setfile, 0);
+	Fl_Button btncancel(260, 220, 80, 24, "&Cancel");
+	btncancel.callback(fltkui_archive_cancel, 0);
+	Fl_Button btnok(350, 220, 40, 24, "&OK");
+	btnok.callback(fltkui_archive_ok, 0);
 
-		romfile = reqfile;
+	romfile = reqfile;
 
-		// Fill the treestore with the filenames
-		while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
-			const char *currentfile = archive_entry_pathname(entry);
-			if (nst_archive_checkext(currentfile) || (!strcasecmp(currentfile, "data"))) {
-				browser->add(currentfile);
-				numarchives++;
-				snprintf(reqfile, reqsize, "%s", currentfile);
-			}
-			archive_read_data_skip(a);
+	// Fill the treestore with the filenames
+	while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+		const char *currentfile = archive_entry_pathname(entry);
+		if (nst_archive_checkext(currentfile) || (!strcasecmp(currentfile, "data"))) {
+			browser->add(currentfile);
+			numarchives++;
+			snprintf(reqfile, reqsize, "%s", currentfile);
 		}
-
-		// Free the archive
-		r = archive_read_free(a);
-
-		// If there are no valid files in the archive, return
-		if (numarchives == 0) {	return false; }
-		// If there's only one file, don't bring up the selector
-		else if (numarchives == 1) { return true; }
-
-		browser->select(1);
-		snprintf(romfile, 256, "%s", browser->text(1));
-
-		window->resizable(browser);
-		window->show();
-		window->set_modal();
-		window->show();
-		while (window->shown()) { Fl::wait(); }
-
-		if (strlen(romfile)) { return true; }
+		archive_read_data_skip(a);
 	}
+
+	// Free the archive
+	r = archive_read_free(a);
+
+	// If there are no valid files in the archive, return
+	if (numarchives == 0) { return false; }
+	// If there's only one file, don't bring up the selector
+	if (numarchives == 1) { return true; }
+
+	// Show selector
+	browser->select(1);
+	snprintf(romfile, 256, "%s", browser->text(1));
+
+	window->resizable(browser);
+	window->show();
+	window->set_modal();
+	window->show();
+	while (window->shown()) { Fl::wait(); }
+
+	if (strlen(romfile)) { return true; }
+
 	return false;
 }

--- a/source/fltkui/fltkui_archive.cpp
+++ b/source/fltkui/fltkui_archive.cpp
@@ -61,6 +61,11 @@ static void fltkui_archive_setfile(Fl_Widget *w, long) {
 }
 
 bool fltkui_archive_select(const char *filename, char *reqfile, size_t reqsize) {
+	// File not compressed
+	if (nst_archive_checkext(filename)) {
+		return false;
+	}
+
 	// Select a filename to pull out of the archive
 	struct archive *a;
 	struct archive_entry *entry;
@@ -69,6 +74,7 @@ bool fltkui_archive_select(const char *filename, char *reqfile, size_t reqsize) 
 	a = archive_read_new();
 	archive_read_support_filter_all(a);
 	archive_read_support_format_all(a);
+	archive_read_support_format_raw(a);
 	r = archive_read_open_filename(a, filename, 10240);
 
 	// Test if it's actually an archive
@@ -94,7 +100,7 @@ bool fltkui_archive_select(const char *filename, char *reqfile, size_t reqsize) 
 		// Fill the treestore with the filenames
 		while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
 			const char *currentfile = archive_entry_pathname(entry);
-			if (nst_archive_checkext(currentfile)) {
+			if (nst_archive_checkext(currentfile) || (!strcasecmp(currentfile, "data"))) {
 				browser->add(currentfile);
 				numarchives++;
 				snprintf(reqfile, reqsize, "%s", currentfile);

--- a/source/fltkui/nstcommon.cpp
+++ b/source/fltkui/nstcommon.cpp
@@ -230,9 +230,7 @@ bool nst_archive_checkext(const char *filename) {
 
 bool nst_archive_select_file(const char *filename, char *reqfile, size_t reqsize) {
 	// File not compressed
-	if (nst_archive_checkext(filename)) {
-		return false;
-	}
+	if (nst_archive_checkext(filename)) { return false; }
 
 	// Select a filename to pull out of the archive
 	struct archive *a;
@@ -250,25 +248,23 @@ bool nst_archive_select_file(const char *filename, char *reqfile, size_t reqsize
 		r = archive_read_free(a);
 		return false;
 	}
-	// If it is an archive, handle it
-	else {
-		// Find files with valid extensions within the archive
-		while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
-			const char *currentfile = archive_entry_pathname(entry);
-			if (nst_archive_checkext(currentfile) || (!strcasecmp(currentfile, "data"))) {
-				numarchives++;
-				snprintf(reqfile, reqsize, "%s", currentfile);
-			}
-			archive_read_data_skip(a);
-			break; // Load the first one found
-		}
-		// Free the archive
-		r = archive_read_free(a);
 
-		// If there are no valid files in the archive, return
-		if (numarchives == 0) {	return false; }
-		else { return true; }
+	// Find files with valid extensions within the archive
+	while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+		const char *currentfile = archive_entry_pathname(entry);
+		if (nst_archive_checkext(currentfile) || (!strcasecmp(currentfile, "data"))) {
+			numarchives++;
+			snprintf(reqfile, reqsize, "%s", currentfile);
+		}
+		archive_read_data_skip(a);
+		break; // Load the first one found
 	}
+	// Free the archive
+	r = archive_read_free(a);
+
+	// If there are no valid files in the archive, return
+	if (numarchives > 0) { return true; }
+
 	return false;
 }
 


### PR DESCRIPTION
This PR extends compressed file support:

* Enable opening `.zst` files by adding the file extension to the open dialog.  `libarchive` already supports zstandard.
* Enable loading directly compressed roms that not contained in archives, like `example.nes.zst`.

Notes:
* Compressed files use `libarchive` format `raw`.
    * It is not enabled by default because it is handled differently from other formats.
* `raw` archives usually contain a single file named `data`.
    * Any archive containing a single file `data` will also attempt to be loaded.  I don't bother detecting this case because the outcome is the same: `Error: Invalid file`
* `raw` archives lack most features of other archives, like `entrysize`.
    * `entrysize` is initialized to `5*1024*1024`, which is far more than enough for NES roms.
    * I decided to use 5MB because it is miniscule on modern hardware and I found examples of multi-roms that were larger than 1MB.