### PR TITLE
FLTK: prevent dangling pointer from temporary string

### DIFF
--- a/source/fltkui/fltkui_settings.cpp
+++ b/source/fltkui/fltkui_settings.cpp
@@ -517,7 +517,8 @@ void InputTable::draw_cell(TableContext context, int r, int c, int x, int y, int
                 }
             }
             else if (c == 2) {
-                text = inputmgr.get_inputdef(std::string(input_info[devicenum].name) + "j", defname).c_str();
+                key = inputmgr.get_inputdef(std::string(input_info[devicenum].name) + "j", defname);
+                text = key.c_str();
             }
 
             fl_draw(text,


### PR DESCRIPTION
Fixes dangling pointer warning, following pattern established in earlier block.
```
source/fltkui/fltkui_settings.cpp:520:24: warning: object backing the pointer text will be destroyed at the end of the full-expression [-Wdangling-assignment-gsl]
  520 |                 text = inputmgr.get_inputdef(std::string(input_info[devicenum].name) + "j", defname).c_str();
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

https://github.com/0ldsk00l/nestopia/blob/39c5eadf5cc6d8e7dd60c8df29460fe7354520de/source/fltkui/fltkui_settings.cpp#L498-L521